### PR TITLE
Fix typo and add more security stuff

### DIFF
--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -128,7 +128,9 @@ class Sandbox {
             '--net', 'none',
             '--entrypoint=\"\"',
             '--cap-drop', 'all',
-            '--security-opts', 'no-new-privileges',
+            '--security-opt', 'no-new-privileges',
+            '--read-only',
+            '--tmpfs', '/usr/src',
             process.env.DOCKER_IMAGE,
             '/bin/bash'
         ];


### PR DESCRIPTION
- Fix a typo: should be `--security-opt` instead of `--security-opts`
- Make container filesystem read-only
  `--read-only`
- Mount `/usr/src` as `tmpfs` (writable) 
  `--tmpfs /usr/src`